### PR TITLE
Fix reference typo in schedule template JS

### DIFF
--- a/lms/templates/ccx/schedule.html
+++ b/lms/templates/ccx/schedule.html
@@ -111,7 +111,7 @@
 <script>
 $(function() {
     schedule_template = _.template($('#ccx-schedule-template').html());
-    var view = new edx.ccxs.schedule.ScheduleView({
+    var view = new edx.ccx.schedule.ScheduleView({
         el: $('#new-ccx-schedule')
     });
     view.render();


### PR DESCRIPTION
This fixes a typo preventing the CCX tabs from rendering.