### PR TITLE
Learning path update

### DIFF
--- a/common/djangoapps/student/exceptions.py
+++ b/common/djangoapps/student/exceptions.py
@@ -1,0 +1,9 @@
+"""
+Exceptions for Students and enrollment
+"""
+
+
+class UserEnrollmentError(Exception):
+    """
+    Raised to indicate an issue with a Student enrolling in a Course
+    """

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -691,8 +691,7 @@ def change_enrollment(request, auto_register=False):
 
     """
     user = request.user
-    multiple_enroll = True  # False
-    redir_url = None
+    multiple_enroll = False
 
     action = request.POST.get("enrollment_action")
     if 'course_id' not in request.POST:
@@ -731,6 +730,8 @@ def change_enrollment(request, auto_register=False):
 
     if len(course_ids) > 1:
         multiple_enroll = True
+    else:
+        course_id = course_ids[0]        
 
     if action == "enroll":
         # Make sure the course exists
@@ -813,7 +814,9 @@ def change_enrollment(request, auto_register=False):
                 if 'start_course_id' in request.session:
                     redir_url = '/courses/{}/courseware'.format(request.session['start_course_id'])
                     del request.session['start_course_id']
-                return HttpResponse(redir_url)
+                    return HttpResponse(redir_url)
+
+                return HttpResponse()
 
         except UserEnrollmentError as e:
             return HttpResponseBadRequest(str(e))
@@ -1842,6 +1845,8 @@ def activate_account(request, key):
 
         if 'start_course_id' in request.session:
             course_start_url = '/courses/{}/courseware'.format(request.session['start_course_id'])
+        else:
+            course_start_url = ''
            
         resp = render_to_response(
             "registration/activation_complete.html",

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -885,7 +885,7 @@ def validate_course_for_user_enrollment(user, course_id):
 
     # check to see if user is currently enrolled in that course
     if CourseEnrollment.is_enrolled(user, course_id):
-        pass
+        raise UserEnrollmentError(_("Student is already enrolled"))
 
     return course
 

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -233,8 +233,8 @@ if settings.COURSEWARE_ENABLED:
         url(r'^courses/?$', 'branding.views.courses', name="courses"),
         url(r'^change_enrollment$',
             'student.views.change_enrollment', name="change_enrollment"),
-        url(r'^multiple_enrollment$',
-            'student.views.multiple_enrollment', name="multiple_enrollment"),
+        url(r'^learning_path_enrollment$',
+             'student.views.learning_path_enrollment', name="learning_path_enrollment"),
         url(r'^change_email_settings$', 'student.views.change_email_settings', name="change_email_settings"),
 
         # Used for an AB-test of auto-registration

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -235,6 +235,8 @@ if settings.COURSEWARE_ENABLED:
             'student.views.change_enrollment', name="change_enrollment"),
         url(r'^learning_path_enrollment$',
              'student.views.learning_path_enrollment', name="learning_path_enrollment"),
+        url(r'^learning_path_start$',
+             'student.views.learning_path_start', name="learning_path_start"),
         url(r'^change_email_settings$', 'student.views.change_email_settings', name="change_email_settings"),
 
         # Used for an AB-test of auto-registration


### PR DESCRIPTION
Add functionality to common.students Django app to support learning paths, namely supporting multiple enrollments at once and redirecting a user to the first module of the first course in the path or the first module of the course selected for starting.  Presently it relies on a hard-coded template found only in the isc-va microsite.